### PR TITLE
Fixed: Building with VS2017+

### DIFF
--- a/Lib/LibStatic/CMakeLists.txt
+++ b/Lib/LibStatic/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.7)
 project(RakNetLibStatic)
 
 FILE(GLOB ALL_HEADER_SRCS ${RakNet_SOURCE_DIR}/Source/*.h)
@@ -17,7 +17,7 @@ IF(WIN32 AND NOT UNIX)
 
 	IF(NOT ${CMAKE_GENERATOR} STREQUAL "MSYS Makefiles")
 
-		IF( MSVC10 OR MSVC11 OR MSVC12 )
+		IF( MSVC_VERSION GREATER_EQUAL 1600 )
 			set_target_properties(RakNetLibStatic PROPERTIES STATIC_LIBRARY_FLAGS "/NODEFAULTLIB:\"LIBCD.lib LIBCMTD.lib MSVCRT.lib\"" )
 		ELSE()
 			set_target_properties(RakNetLibStatic PROPERTIES STATIC_LIBRARY_FLAGS "/NODEFAULTLIB:&quot;LIBCD.lib LIBCMTD.lib MSVCRT.lib&quot;" )


### PR DESCRIPTION
This commit allows building RakNet on Windows with Visual Studio 2017 and 2019 using CMake.